### PR TITLE
templateエンジンにectを導入

### DIFF
--- a/assets/templates/index.ect
+++ b/assets/templates/index.ect
@@ -1,0 +1,7 @@
+<% block 'title': %>トップページ<% end %>
+<% extend 'layout/default.ect' %>
+<h1>Gulp入門</h1>
+<img src="img/sample.png" width="45" alt="">
+<i class="icon icon-facebook"></i>
+<i class="icon icon-twitter"></i>
+<i class="icon icon-insta"></i>

--- a/assets/templates/layout/default.ect
+++ b/assets/templates/layout/default.ect
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title></title>
+  <title><% content 'title' %>| gulp-env page</title>
   <meta name="description" content="">
   <meta name="keywords" content=""/>
   <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0">
@@ -10,11 +10,7 @@
 </head>
 <body>
   <div class="ly-container">
-    <h1>Gulp入門</h1>
-    <img src="img/sample.png" width="45" alt="">
-    <i class="icon icon-facebook"></i>
-    <i class="icon icon-twitter"></i>
-    <i class="icon icon-insta"></i>
+    <% content %>
   </div>
   <!--[if lt IE 9]>
     <script src="js/html5shiv.min.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,3 @@
-// basic paths setting
-var paths = {
-  src : 'assets',
-  tmp : '.tmp',
-  build : 'build'
-};
-
 var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();
 var spritesmith = require('gulp.spritesmith');
@@ -13,6 +6,13 @@ var browserSync = require('browser-sync');
 var runSequence = require('run-sequence');
 var reload = browserSync.reload;
 
+// basic paths setting
+var paths = {
+  src : 'assets',
+  tmp : '.tmp',
+  build : 'build'
+};
+
 // clean
 gulp.task('clean', function (cb) {
   del(paths.tmp, cb);
@@ -20,7 +20,8 @@ gulp.task('clean', function (cb) {
 
 // html
 gulp.task('html', function() {
-  gulp.src(paths.src + '/**/*.html')
+  return gulp.src(paths.src + '/templates/*.ect')
+    .pipe($.ect())
     .pipe(gulp.dest(paths.tmp))
     .pipe(reload({stream:true}));
 });
@@ -125,7 +126,7 @@ gulp.task('build-img', ['img'], function() {
 
 // watch
 gulp.task('watch', ['server'], function(){
-  gulp.watch([paths.src +'/**/*.html'], ['html']);
+  gulp.watch([paths.src +'/**/*.ect'], ['html']);
   gulp.watch([paths.src +'/js/**/*.js'], ['js']);
   gulp.watch([paths.src +'/scss/**/*.scss'], ['sass']);
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "del": "^0.1.3",
     "gulp-autoprefixer": "~1.0.1",
     "gulp-concat": "^2.4.1",
+    "gulp-ect": "^1.3.1",
     "gulp-imagemin": "^1.0.1",
     "gulp-load-plugins": "^0.6.0",
     "gulp-minify-css": "^0.3.10",


### PR DESCRIPTION
とりあえずectをコンパイルできるようにしました。
下記課題が残るがとりあえずマージしたい。

・ectファイルに読込むデータを外部ファイル化したい。
・templates配下にフォルダ構成を持たせたい(フォルダ構成を保ちつつhtml生成してほしい)。
　現状以下の読込みではエラーが出てコンパイルできない為、フォルダ毎に直接記述が必要？
　gulp.src(paths.src + '/*_/_.ect')
