### PR TITLE
ectが参照するデータを外部ファイル化

### DIFF
--- a/assets/data/bar.json
+++ b/assets/data/bar.json
@@ -1,0 +1,7 @@
+{
+  "sample":[
+    {"name":"sample1"},
+    {"name":"sample2"},
+    {"name":"sample3"}
+  ]
+}

--- a/assets/templates/index.ect
+++ b/assets/templates/index.ect
@@ -5,3 +5,11 @@
 <i class="icon icon-facebook"></i>
 <i class="icon icon-twitter"></i>
 <i class="icon icon-insta"></i>
+
+<% if @foo.sample?.length : %>
+  <ul>
+    <% for sample in @foo.sample : %>
+      <li><%= sample.name %></li>
+    <% end %>
+  </ul>
+<% end %>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,10 @@ gulp.task('clean', function (cb) {
 // ect
 gulp.task('ect', function() {
   return gulp.src(paths.src + '/templates/*.ect')
-    .pipe($.ect())
+    .pipe($.ect({data: function (filename, cb) {
+      console.log(filename);
+      cb({foo: require('./assets/data/bar.json')});
+    }}))
     .pipe(gulp.dest(paths.tmp))
     .pipe(reload({stream:true}));
 });


### PR DESCRIPTION
■参照データを外部ファイル化
gulp-ectが提供するAPIであるect()にはオプションとしてテンプレートエンジン内で使用できるコンテキストデータを渡すことができる。
下記の記述で外部ファイルからデータを設定する。
https://github.com/morinpic/gulp-env/compare/feature/data?expand=1#diff-b9e12334e9eafd8341a6107dd98510c9R26

■本家サイト
・[gulp-ect](https://www.npmjs.org/package/gulp-ect)

■各サイト作成時に以下のような使い方を想定
・gulpfile.js側

```
cb({
  food: require('./assets/data/food.json'),
  drink: require('./assets/data/drink.json')
});
```

・ectテンプレート側

```
@foodで参照可能
```
